### PR TITLE
Add generic record reader.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -35,3 +35,9 @@ target_link_libraries(decode_benchmark ${LINK_LIBS})
 
 add_executable(parquet_reader parquet_reader.cc)
 target_link_libraries(parquet_reader ${LINK_LIBS})
+
+add_executable(generic-record-test generic-record-test.cc)
+target_link_libraries(generic-record-test ${LINK_LIBS})
+
+add_executable(parquet-record-reader parquet-record-reader.cc)
+target_link_libraries(parquet-record-reader ${LINK_LIBS})

--- a/example/generic-record-test.cc
+++ b/example/generic-record-test.cc
@@ -1,0 +1,45 @@
+// Copyright 2012 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <parquet/generic-record.h>
+#include <iostream>
+#include <stdio.h>
+
+#include <assert.h>
+
+using namespace boost;
+using namespace parquet_cpp;
+
+void TestStruct() {
+  shared_ptr<GenericStruct> r = GenericStruct::Create();
+  const GenericDatum* v;
+
+  v = r->Get("Doesn't exist");
+  assert(v == NULL);
+
+  r->Put("f", Int32Datum::Create(3));
+  v = r->Get("f");
+  printf("%d\n", v->GetInt32());
+}
+
+int main(int argc, char** argv) {
+  printf("Done.\n");
+  try {
+    TestStruct();
+  } catch (const ParquetException& e) {
+    printf("Failed: %s\n", e.what());
+  }
+
+  return 0;
+}

--- a/example/parquet-record-reader.cc
+++ b/example/parquet-record-reader.cc
@@ -1,0 +1,116 @@
+// Copyright 2012 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <parquet/parquet.h>
+#include <parquet/generic-record.h>
+#include <iostream>
+#include <stdio.h>
+
+#include "example_util.h"
+
+using namespace boost;
+using namespace parquet;
+using namespace parquet_cpp;
+using namespace std;
+
+void ReadParquet(char* filename, vector<int> columns) {
+  FILE* file = fopen(filename, "r");
+  if (file == NULL) {
+    cerr << "Could not open file: " << filename << endl;
+    return;
+  }
+
+  FileMetaData metadata;
+  if (!GetFileMetadata(filename, &metadata)) return;
+
+  if (columns.empty()) {
+    for (int i = 1; i < metadata.schema.size(); ++i) {
+      columns.push_back(i - 1);
+    }
+  }
+
+  for (int i = 0; i < metadata.row_groups.size(); ++i) {
+    const RowGroup& row_group = metadata.row_groups[i];
+
+    vector<InputStream*> streams;
+    vector<const SchemaElement*> projected_cols;
+    vector<const ColumnMetaData*> col_metadata;
+    vector<uint8_t*> col_buffers;
+
+    // Read all the columns we are interested in.
+    for (int c = 0; c < columns.size(); ++c) {
+      int col_idx = columns[c];
+      if (col_idx >= row_group.columns.size()) {
+        cerr << "Invalid col idx." << endl;
+        return;
+      }
+
+      const ColumnChunk& col = row_group.columns[col_idx];
+      size_t col_start = col.meta_data.data_page_offset;
+      if (col.meta_data.__isset.dictionary_page_offset) {
+        if (col_start > col.meta_data.dictionary_page_offset) {
+          col_start = col.meta_data.dictionary_page_offset;
+        }
+      }
+      fseek(file, col_start, SEEK_SET);
+      col_buffers.push_back(new uint8_t[col.meta_data.total_compressed_size]);
+      size_t num_read = fread(col_buffers[c], 1, col.meta_data.total_compressed_size, file);
+      if (num_read != col.meta_data.total_compressed_size) {
+        cerr << "Could not read column data." << endl;
+        continue;
+      }
+
+      streams.push_back(new InMemoryInputStream(col_buffers[c], num_read));
+      projected_cols.push_back(&metadata.schema[col_idx + 1]);
+      col_metadata.push_back(&col.meta_data);
+    }
+
+    RecordReader reader(&metadata, i, projected_cols, col_metadata, streams);
+    printf("Total rows: %ld\n", reader.rows_left());
+
+    while (reader.rows_left() > 0) {
+      vector<shared_ptr<GenericStruct> > records = reader.GetNext();
+      for (int j = 0; j < records.size(); ++j) {
+        printf("%s\n", records[j]->ToString().c_str());
+      }
+    }
+
+    for (int j = 0; j < streams.size(); ++j) {
+      delete streams[j];
+      delete col_buffers[j];
+    }
+  }
+
+  fclose(file);
+}
+
+void PrintUsage() {
+  cerr << "Usage: parquet_reader <file> [col_idx1 col_idx2 etc]" << endl;
+}
+
+// Simple example which prints out the content of the Parquet file
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    PrintUsage();
+    return -1;
+  }
+  vector<int> cols;
+  for (int i = 2; i < argc; ++i) {
+    cols.push_back(atoi(argv[i]));
+  }
+
+  ReadParquet(argv[1], cols);
+  return 0;
+}
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(Parquet STATIC
+  generic-record.cc
   parquet.cc
 )
 

--- a/src/encodings/dictionary-encoding.h
+++ b/src/encodings/dictionary-encoding.h
@@ -65,7 +65,7 @@ class DictionaryDecoder : public Decoder {
         break;
       }
       default:
-        ParquetException::NYI("Unsupported dictionary type");
+        PARQUET_NOT_YET_IMPLEMENTED("Unsupported dictionary type");
     }
   }
 

--- a/src/generic-record.cc
+++ b/src/generic-record.cc
@@ -1,0 +1,119 @@
+// Copyright 2012 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "parquet/generic-record.h"
+
+using namespace boost;
+using namespace parquet;
+using namespace std;
+
+namespace parquet_cpp {
+
+string GenericStruct::ToString() const {
+  stringstream ss;
+  ss << "{ ";
+  bool first = true;
+  for (map<string, shared_ptr<GenericDatum> >::const_iterator it = fields_.begin();
+      it != fields_.end(); ++it) {
+    if (!first) ss << ", ";
+    first = false;
+    ss << it->first << "=" << it->second->ToString();
+  }
+  ss << " }";
+  return ss.str();
+}
+
+RecordReader::RecordReader(const FileMetaData* metadata,
+    int row_group_idx,
+    const vector<const SchemaElement*>& projected_columns,
+    const vector<const ColumnMetaData*>& col_metadata,
+    const vector<InputStream*>& streams)
+  : metadata_(metadata),
+    row_group_idx_(row_group_idx),
+    rows_returned_(0) {
+  if (projected_columns.size() != streams.size()) {
+    throw ParquetException("Invalid input. projected_columns.size() != streams.size()");
+  }
+  if (col_metadata.size() != streams.size()) {
+    throw ParquetException("Invalid input. col_metadata.size() != streams.size()");
+  }
+  if (row_group_idx < 0 || row_group_idx >= metadata->row_groups.size()) {
+    throw ParquetException("Invalid row group index.");
+  }
+
+  for (int i = 0; i < projected_columns.size(); ++i) {
+    readers_.push_back(new ColumnReader(col_metadata[i], projected_columns[i], streams[i]));
+  }
+
+  // TODO: verify schema, handle schema resolution.
+}
+
+RecordReader::~RecordReader() {
+  for (int i = 0; i < readers_.size(); ++i) {
+    delete readers_[i];
+  }
+}
+
+vector<shared_ptr<GenericStruct> > RecordReader::GetNext() {
+  vector<shared_ptr<GenericStruct> > results;
+  while (rows_left() > 0) {
+    shared_ptr<GenericStruct> r = GenericStruct::Create();
+
+    // Loop through each projected column and assemble the record.
+    // TODO: use def/rep level
+    for (int c = 0; c < readers_.size(); ++c) {
+      int def_level, rep_level;
+      switch (readers_[c]->type()) {
+        case Type::BOOLEAN: {
+          bool v = readers_[c]->GetBool(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), BoolDatum::Create(v));
+          break;
+        }
+        case Type::INT32: {
+          int32_t v = readers_[c]->GetInt32(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), Int32Datum::Create(v));
+          break;
+        }
+        case Type::INT64: {
+          int64_t v = readers_[c]->GetInt64(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), Int64Datum::Create(v));
+          break;
+        }
+        case Type::FLOAT: {
+          float v = readers_[c]->GetFloat(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), FloatDatum::Create(v));
+          break;
+        }
+        case Type::DOUBLE: {
+          double v = readers_[c]->GetDouble(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), DoubleDatum::Create(v));
+          break;
+        }
+        case Type::BYTE_ARRAY: {
+          ByteArray v = readers_[c]->GetByteArray(&def_level, &rep_level);
+          r->Put(readers_[c]->name(), ByteArrayDatum::Create(v));
+          break;
+        }
+        default:
+          PARQUET_NOT_YET_IMPLEMENTED("Unsupported type");
+      }
+    }
+    results.push_back(r);
+    ++rows_returned_;
+  }
+
+  return results;
+}
+
+}

--- a/src/parquet.cc
+++ b/src/parquet.cc
@@ -77,7 +77,7 @@ ColumnReader::ColumnReader(const ColumnMetaData* metadata,
       value_byte_size = sizeof(ByteArray);
       break;
     default:
-      ParquetException::NYI("Unsupported type");
+      PARQUET_NOT_YET_IMPLEMENTED("Unsupported type");
   }
 
   switch (metadata->codec) {
@@ -87,7 +87,7 @@ ColumnReader::ColumnReader(const ColumnMetaData* metadata,
       decompressor_.reset(new SnappyCodec());
       break;
     default:
-      ParquetException::NYI("Reading compressed data");
+      PARQUET_NOT_YET_IMPLEMENTED("Reading compressed data");
   }
 
   config_ = Config::DefaultConfig();
@@ -124,7 +124,7 @@ void ColumnReader::BatchDecode() {
           current_decoder_->GetByteArray(reinterpret_cast<ByteArray*>(buf), batch_size);
       break;
     default:
-      ParquetException::NYI("Unsupported type.");
+      PARQUET_NOT_YET_IMPLEMENTED("Unsupported type.");
   }
 }
 
@@ -222,7 +222,7 @@ bool ColumnReader::ReadNewPage() {
           case Encoding::DELTA_BINARY_PACKED:
           case Encoding::DELTA_LENGTH_BYTE_ARRAY:
           case Encoding::DELTA_BYTE_ARRAY:
-            ParquetException::NYI("Unsupported encoding");
+            PARQUET_NOT_YET_IMPLEMENTED("Unsupported encoding");
 
           default:
             throw ParquetException("Unknown encoding type.");

--- a/src/parquet/generic-record.h
+++ b/src/parquet/generic-record.h
@@ -1,0 +1,204 @@
+// Copyright 2012 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PARQUET_GENERIC_RECORD_H
+#define PARQUET_GENERIC_RECORD_H
+
+#include "parquet/parquet.h"
+
+#include <map>
+#include <string>
+#include <vector>
+#include <boost/shared_ptr.hpp>
+#include <boost/lexical_cast.hpp>
+
+namespace parquet_cpp {
+
+// These classes provide a generic record abstraction that fits the parquet
+// data model. It is expected though, that most applications will work directly
+// with their record abstraction (e.g. thrift, avro or protos) without using
+// this class.
+// The focus of this implementation is simplicity and not performance.
+
+// Generic interface for the base types.
+class GenericDatum {
+ public:
+  enum DatumType {
+    PRIMITIVE,
+    LIST,
+    MAP,
+    STRUCT
+  };
+
+  virtual bool GetBool() const = 0;
+  virtual int32_t GetInt32() const = 0;
+  virtual int64_t GetInt64() const = 0;
+  virtual float GetFloat() const = 0;
+  virtual double GetDouble() const = 0;
+  virtual ByteArray GetByteArray() const = 0;
+
+  virtual std::string ToString() const = 0;
+
+  virtual DatumType datum_type() const = 0;
+
+ protected:
+  GenericDatum() {}
+
+ private:
+  GenericDatum(const GenericDatum&);
+  GenericDatum& operator=(const GenericDatum&);
+};
+
+// Templated implementation for GenericDatum, one is stamped out for each
+// type.
+template <typename T>
+class PrimitiveDatum : public GenericDatum {
+ public:
+  static boost::shared_ptr<PrimitiveDatum<T> > Create(T v) {
+    boost::shared_ptr<PrimitiveDatum<T> > d(new PrimitiveDatum<T>(v));
+    return d;
+  }
+
+  virtual std::string ToString() const {
+    return boost::lexical_cast<std::string>(v_);
+  }
+
+  virtual DatumType datum_type() const { return PRIMITIVE; }
+
+  // Template specialization is used so only the one for type T is defined.
+  // e.g., PrimitiveDatum<int> will special GetInt32.
+  virtual bool GetBool() const { throw ParquetException("Unsupported type."); }
+  virtual int32_t GetInt32() const { throw ParquetException("Unsupported type."); }
+  virtual int64_t GetInt64() const { throw ParquetException("Unsupported type."); }
+  virtual float GetFloat() const { throw ParquetException("Unsupported type."); }
+  virtual double GetDouble() const { throw ParquetException("Unsupported type."); }
+  virtual ByteArray GetByteArray() const { throw ParquetException("Unsupported type."); }
+
+  T get() const { return v_; }
+  void set(T v) { v_ = v; }
+
+ private:
+  PrimitiveDatum(T v) : v_(v) { }
+
+  PrimitiveDatum(const PrimitiveDatum&);
+  PrimitiveDatum& operator=(const PrimitiveDatum&);
+
+  T v_;
+};
+
+typedef PrimitiveDatum<bool> BoolDatum;
+typedef PrimitiveDatum<int32_t> Int32Datum;
+typedef PrimitiveDatum<int64_t> Int64Datum;
+typedef PrimitiveDatum<float> FloatDatum;
+typedef PrimitiveDatum<double> DoubleDatum;
+typedef PrimitiveDatum<ByteArray> ByteArrayDatum;
+
+// Template specializations.
+template<> inline bool BoolDatum::GetBool() const { return v_; }
+template<> inline int32_t Int32Datum::GetInt32() const { return v_; }
+template<> inline int64_t Int64Datum::GetInt64() const { return v_; }
+template<> inline float FloatDatum::GetFloat() const { return v_; }
+template<> inline double DoubleDatum::GetDouble() const { return v_; }
+template<> inline ByteArray ByteArrayDatum::GetByteArray() const { return v_; }
+
+template<>
+inline std::string ByteArrayDatum::ToString() const {
+  return std::string(reinterpret_cast<const char*>(v_.ptr), v_.len);
+}
+
+class GenericList {
+ public:
+   const GenericDatum* Get(int idx);
+
+   virtual GenericDatum::DatumType datum_type() const { return GenericDatum::LIST; }
+
+ private:
+  GenericList(const GenericList&);
+  GenericList& operator=(const GenericList&);
+  std::vector<boost::shared_ptr<GenericDatum> > elements_;
+};
+
+class GenericMap {
+ public:
+  const GenericDatum* Get(GenericDatum* key);
+
+  virtual GenericDatum::DatumType datum_type() const { return GenericDatum::MAP; }
+
+ private:
+  GenericMap(const GenericMap&);
+  GenericMap& operator=(const GenericMap&);
+  std::map<boost::shared_ptr<GenericDatum>, boost::shared_ptr<GenericDatum> > elements_;
+};
+
+class GenericStruct {
+ public:
+  virtual GenericDatum::DatumType datum_type() const { return GenericDatum::STRUCT; }
+
+  static boost::shared_ptr<GenericStruct> Create() {
+    return boost::shared_ptr<GenericStruct>(new GenericStruct());
+  }
+
+  const GenericDatum* Get(const std::string& name) const {
+    std::map<std::string, boost::shared_ptr<GenericDatum> >::const_iterator it =
+        fields_.find(name);
+    if (it == fields_.end()) return NULL;
+    return it->second.get();
+  }
+
+  void Put(const std::string& name, const boost::shared_ptr<GenericDatum>& d) {
+    fields_[name] = d;
+  }
+
+
+  std::string ToString() const;
+
+ private:
+  GenericStruct() { }
+  GenericStruct(const GenericStruct&);
+  GenericStruct& operator=(const GenericStruct&);
+
+  std::map<std::string, boost::shared_ptr<GenericDatum> > fields_;
+};
+
+class RecordReader {
+ public:
+  // Creates a record reader for a single row group. This object can then be used
+  // to return batches of rows.
+  RecordReader(const parquet::FileMetaData* metadata,
+      int row_group_idx,
+      const std::vector<const parquet::SchemaElement*>& projected_columns,
+      const std::vector<const parquet::ColumnMetaData*>& projected_metadata,
+      const std::vector<InputStream*>& streams);
+
+  ~RecordReader();
+
+  int64_t rows_left() const {
+    return metadata_->row_groups[row_group_idx_].num_rows - rows_returned_;
+  }
+
+  // Returns the next batch of records.
+  std::vector<boost::shared_ptr<GenericStruct> > GetNext();
+
+ private:
+  const parquet::FileMetaData* metadata_;
+  const int row_group_idx_;
+  std::vector<ColumnReader*> readers_;
+
+  int64_t rows_returned_;
+};
+
+}
+
+#endif
+


### PR DESCRIPTION
This adds a simple generic in memory record and a reader that can
populate it. The in memory recorded is not intended to be used often
since it is expected we will have converters that directly produce
avro/thrift/proto records.

This serves at the first step to supporting nested data types.