### PR TITLE
PARQUET-232: minor compilation issue

### DIFF
--- a/src/parquet.cc
+++ b/src/parquet.cc
@@ -164,7 +164,7 @@ bool ColumnReader::ReadNewPage() {
     }
 
     if (current_page_header_.type == PageType::DICTIONARY_PAGE) {
-      unordered_map<Encoding::type, shared_ptr<Decoder> >::iterator it =
+      boost::unordered_map<Encoding::type, boost::shared_ptr<Decoder> >::iterator it =
           decoders_.find(Encoding::RLE_DICTIONARY);
       if (it != decoders_.end()) {
         throw ParquetException("Column cannot have more than one dictionary.");
@@ -173,7 +173,8 @@ bool ColumnReader::ReadNewPage() {
       PlainDecoder dictionary(schema_->type);
       dictionary.SetData(current_page_header_.dictionary_page_header.num_values,
           buffer, uncompressed_len);
-      shared_ptr<Decoder> decoder(new DictionaryDecoder(schema_->type, &dictionary));
+      boost::shared_ptr<Decoder> decoder(
+          new DictionaryDecoder(schema_->type, &dictionary));
       decoders_[Encoding::RLE_DICTIONARY] = decoder;
       current_decoder_ = decoders_[Encoding::RLE_DICTIONARY].get();
       continue;
@@ -199,14 +200,14 @@ bool ColumnReader::ReadNewPage() {
       Encoding::type encoding = current_page_header_.data_page_header.encoding;
       if (IsDictionaryIndexEncoding(encoding)) encoding = Encoding::RLE_DICTIONARY;
 
-      unordered_map<Encoding::type, shared_ptr<Decoder> >::iterator it =
+      boost::unordered_map<Encoding::type, boost::shared_ptr<Decoder> >::iterator it =
           decoders_.find(encoding);
       if (it != decoders_.end()) {
         current_decoder_ = it->second.get();
       } else {
         switch (encoding) {
           case Encoding::PLAIN: {
-            shared_ptr<Decoder> decoder;
+            boost::shared_ptr<Decoder> decoder;
             if (schema_->type == Type::BOOLEAN) {
               decoder.reset(new BoolDecoder());
             } else {

--- a/src/parquet/parquet.h
+++ b/src/parquet/parquet.h
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <boost/cstdint.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 #include "gen-cpp/parquet_constants.h"
 #include "gen-cpp/parquet_types.h"

--- a/src/parquet/parquet.h
+++ b/src/parquet/parquet.h
@@ -213,7 +213,9 @@ inline ByteArray ColumnReader::GetByteArray(int* def_level, int* rep_level) {
 
 inline bool ColumnReader::ReadDefinitionRepetitionLevels(int* def_level, int* rep_level) {
   *rep_level = 1;
-  if (!definition_level_decoder_->Get(def_level)) ParquetException::EofException();
+  if (definition_level_decoder_ && !definition_level_decoder_->Get(def_level)) {
+    ParquetException::EofException();
+  }
   --num_buffered_values_;
   return *def_level == 0;
 }


### PR DESCRIPTION
I find out some very minor issue when I tried to compile the reader on my environment due to some namespace clashing. 
As example shared_ptr and unordered_map are also in C++11 std namespace. Some compile don't like it.
Also I find that with my test files that I'm reading there was a dereference to a null pointer, if the field is required definition_level_decoder_ is null.